### PR TITLE
Removed the default "create a tag for every build" when seed job produces pipelineJob

### DIFF
--- a/dsl/nightly.dsl
+++ b/dsl/nightly.dsl
@@ -22,6 +22,7 @@ pipelineJob('nightly_intel_testbed') {
                 git(gitUrl)
             }
             scriptPath("./pipeline/intel_testbed.jenkinsfile")
+            extensions { }
         }
     }
 }

--- a/dsl/smoke.dsl
+++ b/dsl/smoke.dsl
@@ -19,7 +19,7 @@ pipelineJob('smoke_intel_testbed') {
     definition {
         cpsScm {
             scm {
-                git(ciUrl)
+                git(vrouterUrl)
             }
             scriptPath("./pipeline/intel_testbed.jenkinsfile")
             extensions { }

--- a/dsl/smoke.dsl
+++ b/dsl/smoke.dsl
@@ -22,6 +22,7 @@ pipelineJob('smoke_intel_testbed') {
                 git(ciUrl)
             }
             scriptPath("./pipeline/intel_testbed.jenkinsfile")
+            extensions { }
         }
     }
 }

--- a/dsl/weekly.dsl
+++ b/dsl/weekly.dsl
@@ -20,9 +20,10 @@ pipelineJob('weekly_intel_testbed') {
     definition {
         cpsScm {
             scm {
-                git(ciUrl)
+                git(vrouterUrl)
             }
             scriptPath("./pipeline/intel_testbed.jenkinsfile")
+            extensions { }
         }
     }
 }


### PR DESCRIPTION
Removed the default "create a tag for every build" when seed job produces pipelineJob